### PR TITLE
Create idea generation endpoint

### DIFF
--- a/10-app/vibes-only-served/src/plugins/swagger.js
+++ b/10-app/vibes-only-served/src/plugins/swagger.js
@@ -11,6 +11,7 @@ async function swaggerPlugin(fastify, opts) {
         { name: 'hello', description: 'Greeting endpoint' },
         { name: 'ops', description: 'Operational endpoints' },
         { name: 'meta', description: 'Meta endpoints' },
+        { name: 'ideas', description: 'Idea generation endpoints' },
       ],
     },
   });

--- a/10-app/vibes-only-served/src/routes/generate-ideas.js
+++ b/10-app/vibes-only-served/src/routes/generate-ideas.js
@@ -1,0 +1,65 @@
+async function routes(fastify) {
+  fastify.get('/api/v1/generate-ideas', {
+    schema: {
+      summary: 'Generate dummy ideas',
+      description: 'Returns N dummy ideas. All ideas are identical except for unique ids.',
+      tags: ['ideas'],
+      querystring: {
+        type: 'object',
+        properties: {
+          count: { type: 'integer', minimum: 1, maximum: 12, default: 1 },
+        },
+        additionalProperties: false,
+      },
+      response: {
+        200: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['id', 'title', 'summary', 'objective', 'tags'],
+            additionalProperties: false,
+            properties: {
+              id: { type: 'string' },
+              title: { type: 'string' },
+              summary: { type: 'string' },
+              objective: { type: 'string' },
+              tags: { type: 'array', items: { type: 'string' } },
+            },
+          },
+        },
+        400: {
+          type: 'object',
+          required: ['error'],
+          properties: { error: { type: 'string' } },
+        },
+      },
+    },
+    errorHandler: (error, request, reply) => {
+      if (error && error.code === 'FST_ERR_VALIDATION') {
+        reply.code(400).send({ error: "Invalid 'count'. Must be an integer between 1 and 12." });
+        return;
+      }
+      throw error;
+    },
+  }, async (request, reply) => {
+    const raw = request.query?.count;
+    const count = raw === undefined ? 1 : Number(raw);
+
+    if (!Number.isInteger(count) || count < 1 || count > 12) {
+      reply.code(400);
+      return { error: "Invalid 'count'. Must be an integer between 1 and 12." };
+    }
+
+    const ideas = Array.from({ length: count }, (_, index) => ({
+      id: `idea-${index + 1}`,
+      title: 'Dummy Idea',
+      summary: 'A placeholder idea for development and testing.',
+      objective: 'Demonstrate the API contract for idea generation.',
+      tags: ['ideation', 'dummy', 'v0'],
+    }));
+
+    return ideas;
+  });
+}
+
+module.exports = routes;

--- a/10-app/vibes-only-served/src/server.js
+++ b/10-app/vibes-only-served/src/server.js
@@ -4,6 +4,7 @@ const { loadEnvConfig } = require('./config/env');
 const registerSwagger = require('./plugins/swagger');
 const helloRoutes = require('./routes/hello');
 const healthRoutes = require('./routes/health');
+const generateIdeasRoutes = require('./routes/generate-ideas');
 
 async function buildServer() {
   const env = loadEnvConfig();
@@ -16,6 +17,7 @@ async function buildServer() {
   await app.register(registerSwagger, { appVersion: env.appVersion });
   await app.register(helloRoutes);
   await app.register(healthRoutes, { appVersion: env.appVersion, gitCommit: env.gitCommit });
+  await app.register(generateIdeasRoutes);
 
   app.get('/openapi.json', {
     schema: {

--- a/10-app/vibes-only-served/test/generate-ideas.spec.js
+++ b/10-app/vibes-only-served/test/generate-ideas.spec.js
@@ -1,0 +1,51 @@
+const t = require('tap');
+const { buildServer } = require('../src/server');
+
+/** @type {import('fastify').FastifyInstance} */
+let app;
+
+t.before(async () => {
+  const built = await buildServer();
+  app = built.app;
+});
+
+t.after(async () => {
+  await app.close();
+});
+
+// Success: count=3
+
+t.test('GET /api/v1/generate-ideas?count=3 returns 3 ideas', async (t) => {
+  const res = await app.inject({ method: 'GET', url: '/api/v1/generate-ideas?count=3' });
+  t.equal(res.statusCode, 200);
+  const body = JSON.parse(res.body);
+  t.equal(Array.isArray(body), true);
+  t.equal(body.length, 3);
+  for (const [i, idea] of body.entries()) {
+    t.match(idea, {
+      id: `idea-${i + 1}`,
+      title: 'Dummy Idea',
+      summary: String,
+      objective: String,
+      tags: Array,
+    });
+  }
+});
+
+// Default: omitted count returns 1
+
+t.test('GET /api/v1/generate-ideas returns 1 idea by default', async (t) => {
+  const res = await app.inject({ method: 'GET', url: '/api/v1/generate-ideas' });
+  t.equal(res.statusCode, 200);
+  const body = JSON.parse(res.body);
+  t.equal(body.length, 1);
+});
+
+// Validation: count > 12
+
+t.test('GET /api/v1/generate-ideas?count=13 returns 400 with message', async (t) => {
+  const res = await app.inject({ method: 'GET', url: '/api/v1/generate-ideas?count=13' });
+  t.equal(res.statusCode, 400);
+  const body = JSON.parse(res.body);
+  t.same(body, { error: "Invalid 'count'. Must be an integer between 1 and 12." });
+});


### PR DESCRIPTION
Add `GET /api/v1/generate-ideas` route to generate dummy ideas.

---
<a href="https://cursor.com/background-agent?bcId=bc-2875c114-2bf0-44cc-bbd5-994f47f66fff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2875c114-2bf0-44cc-bbd5-994f47f66fff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

